### PR TITLE
The deletedb command now deletes the migrations 

### DIFF
--- a/website/management/commands/deletedb.py
+++ b/website/management/commands/deletedb.py
@@ -20,8 +20,6 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
-        os.system('rm website/migrations/*[0-9].py;')   #deletes all of the .py files in the migrations directory except for the __init__.py file.
-        # os.system('find . -path "/website/migrations/*.pyc"  -delete;')  #deletes all of the .pyc files in the migrations directory.
-        os.system('rm db.sqlite3;')  #deletes the database file.
-        #os.system('python manage.py makemigrations website;')  #creates the migration.
-        #os.system('python manage.py migrate;')  #runs the migration.  This will delete all of the data in your database.
+        os.system('rm website/migrations/*.py;')   #deletes all of the .py files in the migrations directory except for the __init__.py file.
+        os.system('touch website/migrations/__init__.py;') #re-create the __init__.py file.
+        os.system('rm db.sqlite3;')  #deletes the database file.        


### PR DESCRIPTION
## Description
1. Name of Branch:
tl-deletedb-fix

2. Tickets related to PR (with links):
N/A

3. Feature/Fix Description:
The old deletedb command was not actually deleting the migrations.  It is now.

4. What architectual changes made:
I made a change to the website/management/commands/deletedb.py file

5. Any dependency changes:
N/A

## Testing
1. New Unit Tests:
N/A

2. All Tests Pass:
N/A

## Documentation
1. Fully completed Documentation with signature:
N/A

2. Readme file updated:
N/A

## Deployment
1. Any new migrations to run:
Yes, but after the delete command has been run.  Please run "python manage.py deletedb" from your terminal.  You will know that the command worked when you only see the __init__.py file in the "website/migrations" directory.  Now run "python manage.py builddb" command.  You will see migrations in the "website/migrations" directory.
