### PR TITLE
Added view for payments, add column is_active to payments, added link…

### DIFF
--- a/website/factories.py
+++ b/website/factories.py
@@ -69,6 +69,7 @@ class PaymentFactory(factory.django.DjangoModelFactory):
     name = factory.Faker('name')
     account_number = factory.Faker('random_int', min=1000000000000000, max=9999999999999999)
     user = factory.Iterator(User.objects.all())
+    is_active = 1
 
 class OrderFactory(factory.django.DjangoModelFactory):
     """

--- a/website/models/models.py
+++ b/website/models/models.py
@@ -28,6 +28,7 @@ class Payment(models.Model):
         User,
         on_delete=models.CASCADE,
     )
+    is_active = models.IntegerField(default=1, choices=options)
 
 
 class Order(models.Model):

--- a/website/templates/profile.html
+++ b/website/templates/profile.html
@@ -1,19 +1,19 @@
 {% load staticfiles %}
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Bangazon</title>
-        {%include "styles.html"%}
-    </head>
+  <head>
+      <title>Bangazon</title>
+      {%include "styles.html"%}
+  </head>
 
-    <body>
-        {%include "navbar.html"%}
-        <h1>View Your Profile</h1>
+  <body>
+      {%include "navbar.html"%}
+      <h1>View Your Profile</h1>
 
-        <div>
+      <div>
+        <a href="{% url 'website:profile/view_payments' %}">View Payments</a>
         <a href="{% url 'website:add_payment' %}">Add Payment</a>
-
-
       </div>
-      </body>
-      </html>
+
+  </body>
+</html>

--- a/website/templates/view_payment_types.html
+++ b/website/templates/view_payment_types.html
@@ -1,0 +1,30 @@
+{% load staticfiles %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Bangazon</title>
+        {%include "styles.html"%}
+    </head>
+    <body>
+        {%include "navbar.html"%}
+        <h4>Your Payment Options.</h4>
+            <ul class="list-inline">
+                {% for payment in payments %}
+                <li class="list-inline-item">{{payment.name}}</li>
+
+                <form class="form-inline" action="{% url 'website:profile/view_payments' %}" method="post">
+                {% csrf_token %}
+
+                    <input class="form-control" name="delete_payment" type="hidden" value="{{ payment.id }}"/>
+                    <input class="form-control btn btn-danger" type="submit" value="Delete Payment"/>
+
+                </form>
+
+                {% endfor %}
+            </ul>
+            {% if not payments  %}
+            <a href="{% url 'website:add_payment' %}" class="btn btn-success">Create Payment</a>
+            {% endif %}
+    </body>
+</html>

--- a/website/urls.py
+++ b/website/urls.py
@@ -19,5 +19,6 @@ urlpatterns = [
     url(r'^payment$', view_payments, name='payment'),
     url(r'^confirmation$', confirm_order, name='confirmation'),
     url(r'^profile$', profile, name='profile'),
-    url(r'^add_payment$', add_payment, name='add_payment')
+    url(r'^add_payment$', add_payment, name='add_payment'),
+    url(r'^profile/view_payments$', view_payments, name='profile/view_payments')
 ]

--- a/website/views/view_payments.py
+++ b/website/views/view_payments.py
@@ -18,10 +18,39 @@ def view_payments(request):
     """
     form_data = request.POST
 
-    payments = Payment.objects.filter(user=request.user)
 
-    context = { 'payments': payments, 'order_id': form_data['order_id'] }
-    template_name = 'choose_payment.html'
+    try:
+        if form_data['order_id']:
+            payments = Payment.objects.filter(user=request.user, is_active=1)
+            context = { 'payments': payments, 'order_id': form_data['order_id'] }
+            template_name = 'choose_payment.html'
+            return render(request, template_name, context)
+    except KeyError:
+        pass
+
+    try:
+        if form_data['delete_payment']:
+            payment_id = form_data['delete_payment']
+
+            payment = Payment.objects.get(user=request.user, id=payment_id)
+            order_on_payment = Order.objects.filter(user=request.user, payment=payment)
+
+            if not order_on_payment:
+                payment.delete()
+            else:
+                # 1 is True, 0 is False
+                payment.is_active = 0
+                payment.save()
+
+            
+    except KeyError:
+        pass
+
+    payments = Payment.objects.filter(user=request.user, is_active=1)
+    context = { 'payments': payments }
+    template_name = 'view_payment_types.html'
     return render(request, template_name, context)
+
+
 
     


### PR DESCRIPTION
User can delete a payment type

## Description
1. Name of Branch:
```am-delete-payment-option```

2. Tickets related to PR (with links):
[User can delete a payment type](https://github.com/handy-pandas/djangazon/issues/8)

3. Feature/Fix Description:
Added view for payments in profile page.
Allowed user to view and delete payment options

4. What architectual changes made:
Added column 'is_active' to payment table
Update factories.py to represent correct table values
added template for profile view payments

5. Any dependency changes:
No

## Testing
1. To Review:
```python manage.py deletedb```
```python manage.py builddb```
```python manage.py runserver```
open your local host server address displayed in the terminal
register a new user
create 2 payment types
complete an order using one of the payment types
delete both payment types from your profile/payments page
check db.browser for the payment type that doesn't have an order attached to be completely removed
check db.browser for the payment type that does have an order attached to be updated on column 'is_active' to 0 but still exist in the database.

1. New Unit Tests:
No

1. All Tests Pass:
Yes

## Documentation
1. Fully completed Documentation with signature:
Yes sir

2. Readme file updated:
No

## Deployment
1. Any new migrations to run:
YES !
```python manage.py deletedb```
```python manage.py builddb````
